### PR TITLE
required paired observationContext and observations

### DIFF
--- a/submit.xsd
+++ b/submit.xsd
@@ -113,8 +113,10 @@
   <xsd:element name="observationBatch">
     <xsd:complexType>
       <xsd:sequence maxOccurs="unbounded">
-        <xsd:element ref="observationContext"/>
-        <xsd:element ref="observations"/>
+        <xsd:sequence>
+          <xsd:element ref="observationContext"/>
+          <xsd:element ref="observations"/>
+        </xsd:sequence>
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>


### PR DESCRIPTION
This is a minimal quick fix for https://github.com/IAU-ADES/xsd/issues/2  (and not meant to preclude proposed changes in https://github.com/IAU-ADES/xsd/tree/sch)

Tested to still validate `submit.xml` but to reject `submit_ko_01.xml`.
