### PR TITLE
address mix of optical and radar

### DIFF
--- a/submit.xsd
+++ b/submit.xsd
@@ -85,12 +85,10 @@
 
   <xsd:element name="observations">
     <xsd:complexType>
-      <xsd:sequence>
-        <xsd:choice maxOccurs="unbounded"> 
-          <xsd:element ref="optical"/>
-          <xsd:element ref="radar"/>
-        </xsd:choice>
-      </xsd:sequence>
+      <xsd:choice> 
+        <xsd:element ref="optical" maxOccurs="unbounded"/>
+        <xsd:element ref="radar"   maxOccurs="unbounded"/>
+      </xsd:choice>
     </xsd:complexType>
   </xsd:element>
 


### PR DESCRIPTION
addresses https://github.com/IAU-ADES/xsd/issues/6

submit.xsd only: disallow mix of optical and radar observations in a single observation list.

Tested to still validate submit.xml and also a file with radar, but not validate a file with a mix.
